### PR TITLE
Framebuffer clear validation error fixed

### DIFF
--- a/Source/ApplicationCore/Device.cpp
+++ b/Source/ApplicationCore/Device.cpp
@@ -164,9 +164,24 @@ VkExtent2D Device::GetSwapChainExtent() const
     return swapChain.GetSwapExtent();
 }
 
+VkFormat Device::GetSwapChainFormat() const
+{
+    return swapChain.GetImageFormat();
+}
+
 VkFramebuffer Device::GetCurrentFramebuffer() const
 {
     return swapChain.GetFramebuffer(currentImageIndex);
+}
+
+VkImage Device::GetCurrentSwapChainImage() const
+{
+    return swapChain.GetImage(currentImageIndex);
+}
+
+VkImageView Device::GetCurrentSwapChainImageView() const
+{
+    return swapChain.GetImageView(currentImageIndex);
 }
 
 VkCommandPool Device::GetCommandPool() const
@@ -365,6 +380,36 @@ void Device::TransitionImageLayout(VkImage image, VkFormat format, VkImageLayout
         barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
         sourceStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
         destinationStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+    }
+    else if (oldLayout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR)
+    {
+        barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        barrier.dstAccessMask = 0;
+        sourceStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        destinationStage = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+    }
+    else if (oldLayout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR && newLayout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
+    {
+        barrier.srcAccessMask = 0;
+        barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+
+        sourceStage = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+        destinationStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    }
+    else if (oldLayout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR && newLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL)
+    {
+        barrier.srcAccessMask = 0;
+        barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+
+        sourceStage = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+        destinationStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+    }
+    else if (oldLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
+    {
+        barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        sourceStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+        destinationStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
     }
 
     vkCmdPipelineBarrier(commandBuffer, sourceStage, destinationStage, 0, 0, nullptr, 0, nullptr, 1, &barrier);

--- a/Source/ApplicationCore/Device.h
+++ b/Source/ApplicationCore/Device.h
@@ -44,7 +44,10 @@ public:
 	VkDevice GetVulkanDevice() const;
 	VkRenderPass& GetRenderPass();
 	VkExtent2D GetSwapChainExtent() const;
+	VkFormat GetSwapChainFormat() const;
 	VkFramebuffer GetCurrentFramebuffer() const;
+	VkImage GetCurrentSwapChainImage() const;
+	VkImageView GetCurrentSwapChainImageView() const;
 	VkCommandPool GetCommandPool() const;
 	VkCommandBuffer GetCurrentCommandBuffer() const;
 	VkQueue GetGraphicsQueue() const;

--- a/Source/ApplicationCore/SwapChain.cpp
+++ b/Source/ApplicationCore/SwapChain.cpp
@@ -36,7 +36,7 @@ void SwapChain::Setup(VkPhysicalDevice device, VkSurfaceKHR surface)
     createInfo.imageExtent = extent;
     createInfo.imageColorSpace = surfaceFormat.colorSpace;
     createInfo.imageArrayLayers = 1;
-    createInfo.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    createInfo.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
 
     indices = FindQueueFamilies(device, surface);
     uint32_t queueFamilyIndices[] = { indices.graphicsFamily.value(), indices.presentFamily.value() };
@@ -239,6 +239,16 @@ void SwapChain::PresentNextImage(int currentImageIndex)
 VkFramebuffer SwapChain::GetFramebuffer(int currentImageIndex) const
 {
     return swapChainFramebuffers[currentImageIndex];
+}
+
+VkImage SwapChain::GetImage(int currentImageIndex) const
+{
+    return swapChainImages[currentImageIndex];
+}
+
+VkImageView SwapChain::GetImageView(int currentImageIndex) const
+{
+    return swapChainImageViews[currentImageIndex];
 }
 
 VkFormat SwapChain::GetImageFormat() const

--- a/Source/ApplicationCore/SwapChain.h
+++ b/Source/ApplicationCore/SwapChain.h
@@ -30,6 +30,8 @@ public:
 	void PresentNextImage(int currentImageIndex);
 
 	VkFramebuffer GetFramebuffer(int currentImageIndex) const;
+	VkImage GetImage(int currentImageIndex) const;
+	VkImageView GetImageView(int currentImageIndex) const;
 	VkFormat GetImageFormat() const;
 	VkExtent2D GetSwapExtent() const;
 	VkRenderPass& GetRenderPass();


### PR DESCRIPTION
Fixed a bug where the validation layers would throw errors when the framebuffer was cleared. This is due to the incorrect clear function used.